### PR TITLE
Fix async forEach issue

### DIFF
--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
@@ -279,32 +279,36 @@ export class WorkflowCommonWorkspaceService {
       withDeleted: true,
     });
 
-    workflowVersions.forEach((workflowVersion) => {
-      workflowVersion.steps?.forEach(async (step) => {
-        if (step.type === WorkflowActionType.CODE) {
-          switch (operation) {
-            case 'delete':
-              await this.serverlessFunctionService.deleteOneServerlessFunction({
-                id: step.settings.input.serverlessFunctionId,
-                workspaceId,
-                softDelete: true,
-              });
-              break;
-            case 'restore':
-              await this.serverlessFunctionService.restoreOneServerlessFunction(
-                step.settings.input.serverlessFunctionId,
-              );
-              break;
-            case 'destroy':
-              await this.serverlessFunctionService.deleteOneServerlessFunction({
-                id: step.settings.input.serverlessFunctionId,
-                workspaceId,
-                softDelete: false,
-              });
-              break;
-          }
+    for (const workflowVersion of workflowVersions) {
+      const steps = workflowVersion.steps ?? [];
+
+      for (const step of steps) {
+        if (step.type !== WorkflowActionType.CODE) {
+          continue;
         }
-      });
-    });
+
+        switch (operation) {
+          case 'delete':
+            await this.serverlessFunctionService.deleteOneServerlessFunction({
+              id: step.settings.input.serverlessFunctionId,
+              workspaceId,
+              softDelete: true,
+            });
+            break;
+          case 'restore':
+            await this.serverlessFunctionService.restoreOneServerlessFunction(
+              step.settings.input.serverlessFunctionId,
+            );
+            break;
+          case 'destroy':
+            await this.serverlessFunctionService.deleteOneServerlessFunction({
+              id: step.settings.input.serverlessFunctionId,
+              workspaceId,
+              softDelete: false,
+            });
+            break;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- avoid `async` inside `forEach` when handling serverless sub-entities

## Testing
- `yarn test` *(fails: unable to download yarn packages)*

------
https://chatgpt.com/codex/tasks/task_e_686a26c93f888324b3c29cb6b1fb135b